### PR TITLE
install pgcrypto to the correct schema

### DIFF
--- a/email_hasher/hash-augur-email.py
+++ b/email_hasher/hash-augur-email.py
@@ -55,7 +55,7 @@ def main(secret_key):
     cursor = conn.cursor()
     try:
         # Ensure the pgcrypto extension is available.
-        cursor.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto;")
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA augur_data;")
         conn.commit()
 
         # List of columns to encrypt.


### PR DESCRIPTION
When trying to run the email encryption tool, I noticed it was saying that the encryption function did not exist.

this was because it was being installed to the `public` schema, not `augur_data`. This fixes that.

Existing databases where this extension is installed will likely need to run `DROP EXTENSION pgcrypto;` first for this to work 